### PR TITLE
Reset the timer after SIGINT (so that SIGKILL will really be sent).

### DIFF
--- a/workers.go
+++ b/workers.go
@@ -199,7 +199,8 @@ func terminate(reflex *Reflex) {
 					return
 				}
 			}
-			// After SIGINT doesn't do anything, try SIGKILL.
+			// After SIGINT doesn't do anything, try SIGKILL 5 seconds later.
+			timer.Reset(5000 * time.Millisecond)
 			sig = syscall.SIGKILL
 		}
 	}


### PR DESCRIPTION
My previous pull request contained a bug where I forgot to rearm the timer after SIGINT (just found this by trying to restart a program that ignores SIGINT...).
Trivial pull request to fix this (I gave the program a few more seconds before SIGKILL on the basis that a program that deliberately catches sigint may be doing some important cleanup then... but you may want to change this value if you think it is too long).
Apologies for the bug...
