### PR TITLE
make shutdown timeout configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,3 +294,4 @@ See [issue #6](https://github.com/cespare/reflex/issues/6) for some more backgro
 * Rich Liebling ([rliebling](https://github.com/rliebling))
 * Seth W. Klein ([sethwklein](https://github.com/sethwklein))
 * Vincent Vanackere ([vanackere](https://github.com/vanackere))
+* Benedikt Böhm ([hollow](https://github.com/hollow))

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ OPTIONS are given below:
             A regular expression to match filenames. (May be repeated.)
   -e, --sequential=false:
             Don't run multiple commands at the same time.
+  -t, --shutdown-timeout=500ms:
+            Number of seconds to wait for shutdown.
   -s, --start-service=false:
             Indicates that the command is a long-running process to be
             restarted on matching changes.
@@ -290,8 +292,8 @@ See [issue #6](https://github.com/cespare/reflex/issues/6) for some more backgro
 
 ## Authors
 
+* Benedikt Böhm ([hollow](https://github.com/hollow))
 * Caleb Spare ([cespare](https://github.com/cespare))
 * Rich Liebling ([rliebling](https://github.com/rliebling))
 * Seth W. Klein ([sethwklein](https://github.com/sethwklein))
 * Vincent Vanackere ([vanackere](https://github.com/vanackere))
-* Benedikt Böhm ([hollow](https://github.com/hollow))

--- a/config.go
+++ b/config.go
@@ -13,18 +13,18 @@ import (
 )
 
 type Config struct {
-	command []string
-	source  string
-
-	regexes        []string
-	globs          []string
-	inverseRegexes []string
-	inverseGlobs   []string
-	subSymbol      string
-	startService   bool
-	onlyFiles      bool
-	onlyDirs       bool
-	allFiles bool
+	command         []string
+	source          string
+	regexes         []string
+	globs           []string
+	inverseRegexes  []string
+	inverseGlobs    []string
+	subSymbol       string
+	startService    bool
+	shutdownTimeout int
+	onlyFiles       bool
+	onlyDirs        bool
+	allFiles        bool
 }
 
 func (c *Config) registerFlags(f *flag.FlagSet) {
@@ -44,6 +44,8 @@ func (c *Config) registerFlags(f *flag.FlagSet) {
 	f.BoolVarP(&c.startService, "start-service", "s", false, `
             Indicates that the command is a long-running process to be
             restarted on matching changes.`)
+	f.IntVarP(&c.shutdownTimeout, "shutdown-timeout", "t", 60, `
+            Number of seconds to wait for shutdown.`)
 	f.BoolVar(&c.onlyFiles, "only-files", false, `
             Only match files (not directories).`)
 	f.BoolVar(&c.onlyDirs, "only-dirs", false, `

--- a/config.go
+++ b/config.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/kballard/go-shellquote"
 	flag "github.com/ogier/pflag"
@@ -21,7 +22,7 @@ type Config struct {
 	inverseGlobs    []string
 	subSymbol       string
 	startService    bool
-	shutdownTimeout int
+	shutdownTimeout time.Duration
 	onlyFiles       bool
 	onlyDirs        bool
 	allFiles        bool
@@ -44,7 +45,7 @@ func (c *Config) registerFlags(f *flag.FlagSet) {
 	f.BoolVarP(&c.startService, "start-service", "s", false, `
             Indicates that the command is a long-running process to be
             restarted on matching changes.`)
-	f.IntVarP(&c.shutdownTimeout, "shutdown-timeout", "t", 60, `
+	f.DurationVarP(&c.shutdownTimeout, "shutdown-timeout", "t", 500*time.Millisecond, `
             Number of seconds to wait for shutdown.`)
 	f.BoolVar(&c.onlyFiles, "only-files", false, `
             Only match files (not directories).`)

--- a/reflex.go
+++ b/reflex.go
@@ -77,6 +77,10 @@ func NewReflex(c *Config) (*Reflex, error) {
 		return nil, errors.New("cannot specify both --only-files and --only-dirs")
 	}
 
+	if c.shutdownTimeout <= 0 {
+		return nil, errors.New("shutdown timeout cannot be <= 0")
+	}
+
 	reflex := &Reflex{
 		id:           reflexID,
 		source:       c.source,
@@ -88,7 +92,7 @@ func NewReflex(c *Config) (*Reflex, error) {
 		command:      c.command,
 		subSymbol:    c.subSymbol,
 		done:         make(chan struct{}),
-		timeout:      time.Duration(c.shutdownTimeout) * time.Second,
+		timeout:      c.shutdownTimeout,
 		mu:           &sync.Mutex{},
 	}
 	reflexID++


### PR DESCRIPTION
this patch makes the shutdown timeout configurable and sets the default timeout to 60 seconds, so server processes which take a few seconds to shutdown gracefully get a chance to do so