### PR TITLE
Use Travis CI to Run Tests and Build Binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ sudo: false
 language: go
 go: 1.4
 before_deploy:
-  - GOOS=darwin GOARCH=amd64 go build -v -o reflex_darwin_amd64 ./...
-  - GOOS=linux GOARCH=amd64 go build -v -o reflex_linux_amd64 ./...
+  - go get github.com/mitchellh/gox
+  - gox -build-toolchain
+  - gox --osarch "linux/amd64 darwin/amd64" --output "reflex_{{.OS}}_{{.Arch}}"
 deploy:
   provider: releases
   api_key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ deploy:
   - reflex_darwin_amd64
   - reflex_linux_amd64
   on:
-    repo: nnutter/reflex
+    repo: cespare/reflex
     all_branches: true
     tags: true
     go: go1.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ go: 1.4
 before_deploy:
   - go get github.com/mitchellh/gox
   - gox -build-toolchain
-  - gox --osarch "linux/amd64 darwin/amd64" --output "reflex_{{.OS}}_{{.Arch}}"
+  - gox -osarch "linux/amd64 darwin/amd64" -output "reflex_{{.OS}}_{{.Arch}}"
 deploy:
   provider: releases
   api_key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: go
 go: 1.4
 before_deploy:
   - go get github.com/mitchellh/gox
-  - gox -build-toolchain
+  - gox -osarch "linux/amd64 darwin/amd64" -build-toolchain
   - gox -osarch "linux/amd64 darwin/amd64" -output "reflex_{{.OS}}_{{.Arch}}"
 deploy:
   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+sudo: false
+language: go
+go: 1.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,18 @@
 sudo: false
 language: go
 go: 1.4
+before_deploy:
+  - GOOS=darwin GOARCH=amd64 go build -v -o reflex_darwin_amd64 ./...
+  - GOOS=linux GOARCH=amd64 go build -v -o reflex_linux_amd64 ./...
+deploy:
+  provider: releases
+  api_key:
+    secure: kogIZcMXByjEB6KwTYR/h9CzYkwBxiTyNcmi8cWEf8MNF2IIn5I8g3Pg87Wx0qAjd92HR4i/SMROxffHJzPO2UCuTcoZAyaKuXR7/jaaML6JY/2rhL44sjrUFJ8JLyhCKPh4IznjjT2TzpgCF13khyJIpchUWG3UQCIxYjbgGRU=
+  file:
+  - reflex_darwin_amd64
+  - reflex_linux_amd64
+  on:
+    repo: nnutter/reflex
+    all_branches: true
+    tags: true
+    go: go1.4

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ get` will automatically fetch them for you.
 
 Reflex probably only works on Linux and Mac OS.
 
-TODO: provide compiled downloads for linux/darwin amd64.
+Binaries can be downloaded on the [cespare/reflex releases](https://github.com/cespare/reflex/releases) page.
 
 ## Usage
 


### PR DESCRIPTION
I saw the `README.md` mentioned,

> TODO: provide compiled downloads for linux/darwin amd64.

One way to do that (automatically) is using Travis CI.  This PR provides a Travis CI config to help get you started.  You will need to take several actions in addition to merging this PR to make it work.

1. You will need to enable Travis CI for `cespare/reflex`.
    1. Sign into Travis CI.
    1. After your repos have synced enable `cespare/reflex` on your [profile page](https://travis-ci.org/profile).
    1. I also recommend clicking on the wrench icon and enabling the _Build only if .travis.yml is present_ option.
1. You will need to create a [Personal Access Token](https://github.com/settings/applications#personal-access-tokens) on GitHub.
    1. Click _Generate new token_.
    1. Enter something like, "automatic releases for cespare/reflex", for the _Token description_.
    1. Leave only `repo` and `public_repo` checked.
    1. Click _Generate token_.
    1. Copy token to clipboard and save it somewhere; GitHub only shows it to you once.
1. You will need to set the `deploy.api_key` using your GitHub token.
    1. Install the Travis CI CLI tool, `gem install --no-document --travis`.
    1. From your `cespare/reflex` clone, run `travis encrypt --add deploy.api_key <token>` to put the encrypted OAUTH token in `.travis.yml`.
    1. I noticed that `travis` munged the indentation on the `before_deploy` lines so manually edited the `.travis.yml` after.
    1. Add, commit, and push the new `deploy.api_key`.

With this configuration Travis CI will run tests on all pushes and PRs and will build `linux/amd64` and `darwin/amd64` binaries when you tag a release.  Check out [my fork's releases](https://github.com/nnutter/reflex/releases) page for an example.