### PR TITLE
Watch specific paths

### DIFF
--- a/config.go
+++ b/config.go
@@ -30,7 +30,8 @@ type Config struct {
 
 func (c *Config) registerFlags(f *flag.FlagSet) {
 	f.VarP(newMultiString(nil, &c.paths), "path", "p", `
-            A directory to watch recursively. If used, ONLY paths specified will be watchedj (May be repeated.)`)
+            A directory to watch recursively.
+            If used, ONLY paths specified will be watched (May be repeated.)`)
 	f.VarP(newMultiString(nil, &c.regexes), "regex", "r", `
             A regular expression to match filenames. (May be repeated.)`)
 	f.VarP(newMultiString(nil, &c.inverseRegexes), "inverse-regex", "R", `

--- a/config.go
+++ b/config.go
@@ -20,14 +20,17 @@ type Config struct {
 	globs          []string
 	inverseRegexes []string
 	inverseGlobs   []string
+	paths          []string
 	subSymbol      string
 	startService   bool
 	onlyFiles      bool
 	onlyDirs       bool
-	allFiles bool
+	allFiles       bool
 }
 
 func (c *Config) registerFlags(f *flag.FlagSet) {
+	f.VarP(newMultiString(nil, &c.paths), "path", "p", `
+            A directory to watch recursively. If used, ONLY paths specified will be watchedj (May be repeated.)`)
 	f.VarP(newMultiString(nil, &c.regexes), "regex", "r", `
             A regular expression to match filenames. (May be repeated.)`)
 	f.VarP(newMultiString(nil, &c.inverseRegexes), "inverse-regex", "R", `

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ const defaultSubSymbol = "{}"
 
 var (
 	reflexes []*Reflex
+	paths    []string
 
 	flagConf       string
 	flagSequential bool
@@ -160,6 +161,11 @@ func main() {
 			fmt.Println(reflex)
 		}
 		reflexes = append(reflexes, reflex)
+		paths = append(paths, config.paths...)
+	}
+
+	if len(paths) == 0 {
+		paths = append(paths, ".")
 	}
 
 	// Catch ctrl-c and make sure to kill off children.
@@ -185,7 +191,7 @@ func main() {
 	for i := range reflexes {
 		broadcastChanges[i] = make(chan string)
 	}
-	go watch(".", watcher, changes, done, reflexes)
+	go watch(paths, watcher, changes, done, reflexes)
 	go broadcast(broadcastChanges, changes)
 	go printOutput(stdout, os.Stdout)
 

--- a/watch.go
+++ b/watch.go
@@ -14,9 +14,11 @@ const chmodMask fsnotify.Op = ^fsnotify.Op(0) ^ fsnotify.Chmod
 // It sends an error on the done chan.
 // As an optimization, any dirs we encounter that meet the ExcludePrefix criteria of all reflexes can be
 // ignored.
-func watch(root string, watcher *fsnotify.Watcher, names chan<- string, done chan<- error, reflexes []*Reflex) {
-	if err := filepath.Walk(root, walker(watcher, reflexes)); err != nil {
-		infoPrintf(-1, "Error while walking path %s: %s", root, err)
+func watch(root []string, watcher *fsnotify.Watcher, names chan<- string, done chan<- error, reflexes []*Reflex) {
+	for _, item := range root {
+		if err := filepath.Walk(item, walker(watcher, reflexes)); err != nil {
+			infoPrintf(-1, "Error while walking path %s: %s", root, err)
+		}
 	}
 
 	for {


### PR DESCRIPTION
## Change

Allow paths to be watched to be specified.

## Rational

While working on a project, I realized that I needed to watch directories outside the current path. Trying to exclude all other paths would be impractical, so I wrote this patch to allow only specific directories to be watched.

This change is backwards compatible with the current reflex and adds a command line switch to specify the paths that will be included.

## New usage:

`reflex -p ../path_to_lib -p path_to_files echo "file changed is {}"`

If a path is not specified, the the current directory will be used (as with current reflex).