### PR TITLE
 Support continuation lines and multi-line strings in config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ background on this issue.
 
 * Benedikt Böhm ([hollow](https://github.com/hollow))
 * Caleb Spare ([cespare](https://github.com/cespare))
+* PJ Eby ([pjeby](https://github.com/pjeby))
 * Rich Liebling ([rliebling](https://github.com/rliebling))
 * Seth W. Klein ([sethwklein](https://github.com/sethwklein))
 * Vincent Vanackere ([vanackere](https://github.com/vanackere))

--- a/README.md
+++ b/README.md
@@ -138,13 +138,17 @@ reflex a configuration file.
 
 The configuration file syntax is simple: each line is a command, and each
 command is composed of flags and arguments -- just like calling reflex but
-without the initial `reflex`. Lines that start with `#` are ignored. Here's an
-example:
+without the initial `reflex`. Lines that start with `#` are ignored. Commands
+can span multiple lines if they're \\-continued, or include multi-line strings.
+Here's an example:
 
     # Rebuild SCSS when it changes
-    -r '\.scss$' -- sh -c 'sass {} `basename {} .scss`.css'
+    -r '\.scss$' -- \
+       sh -c 'sass {} `basename {} .scss`.css'
+    
     # Restart server when ruby code changes
-    -sr '\.rb$' -- ./bin/run_server.sh
+    -sr '\.rb$' -- \
+        ./bin/run_server.sh
 
 If you want to change the configuration file and have reflex reload it on the
 fly, you can run reflex inside reflex:

--- a/config.go
+++ b/config.go
@@ -89,6 +89,10 @@ parseFile:
 
 		// Found a command line; begin parsing it
 		errorf := fmt.Sprintf("error on line %d of %s: %%s", lineNo, name)
+
+		c := &Config{}
+		c.source = fmt.Sprintf("%s, line %d", name, lineNo)
+
 		line := scanner.Text()
 		parts, err := shellquote.Split(line)
 
@@ -112,16 +116,13 @@ parseFile:
 			parts, err = shellquote.Split(line)
 		}
 
-		c := &Config{}
 		flags := flag.NewFlagSet("", flag.ContinueOnError)
 		flags.SetOutput(ioutil.Discard)
 		c.registerFlags(flags)
-
 		if err := flags.Parse(parts); err != nil {
 			return nil, fmt.Errorf(errorf, err)
 		}
 		c.command = flags.Args()
-		c.source = fmt.Sprintf("%s, line %d", name, lineNo)
 		configs = append(configs, c)
 	}
 	if err := scanner.Err(); err != nil {

--- a/config_test.go
+++ b/config_test.go
@@ -14,8 +14,12 @@ func TestReadConfigs(t *testing.T) {
 
 # Some comment here
 -r '^a[0-9]+\.txt$' --only-dirs --substitute='[]' echo []
+
 -g '*.go' -s --only-files echo hi
--r foo -r bar -R baz -g a -G b -G c echo hi
+
+-r foo -r bar -R baz -g a \
+	-G b -G c echo "hello
+world"
 `
 
 	got, err := readConfigsFromReader(strings.NewReader(in), "test input")
@@ -40,7 +44,7 @@ func TestReadConfigs(t *testing.T) {
 		},
 		{
 			command:         []string{"echo", "hi"},
-			source:          "test input, line 5",
+			source:          "test input, line 6",
 			globs:           []string{"*.go"},
 			subSymbol:       "{}",
 			startService:    true,
@@ -48,8 +52,8 @@ func TestReadConfigs(t *testing.T) {
 			onlyFiles:       true,
 		},
 		{
-			command:         []string{"echo", "hi"},
-			source:          "test input, line 6",
+			command:         []string{"echo", "hello\nworld"},
+			source:          "test input, line 10",
 			regexes:         []string{"foo", "bar"},
 			globs:           []string{"a"},
 			inverseRegexes:  []string{"baz"},

--- a/config_test.go
+++ b/config_test.go
@@ -53,7 +53,7 @@ world"
 		},
 		{
 			command:         []string{"echo", "hello\nworld"},
-			source:          "test input, line 10",
+			source:          "test input, line 8",
 			regexes:         []string{"foo", "bar"},
 			globs:           []string{"a"},
 			inverseRegexes:  []string{"baz"},


### PR DESCRIPTION
Currently, each pattern/action combination in a config file must be all on one line, which can lead to having some very long lines.  Also, if you need to pass a multi-line string to anything, it's not possible.

This PR adjusts the config parsing loop to handle \\-continued lines and multi-line strings.  For ease of debugging, line numbers in configuration sources and errors are reported as though that configuration were written entirely on their first line.