### PR TITLE
Prevent duplicate command runs with intermediate file states

### DIFF
--- a/reflex.go
+++ b/reflex.go
@@ -153,9 +153,12 @@ func (r *Reflex) filterMatching(out chan<- string, in <-chan string) {
 //   In the meantime, keep batching. When we've sent off all the batched
 //   messages, go back to the beginning.
 func (r *Reflex) batch(out chan<- string, in <-chan string) {
+
+	const silenceInterval = 300 * time.Millisecond
+
 	for name := range in {
 		r.backlog.Add(name)
-		timer := time.NewTimer(300 * time.Millisecond)
+		timer := time.NewTimer(silenceInterval)
 	outer:
 		for {
 			select {
@@ -164,7 +167,7 @@ func (r *Reflex) batch(out chan<- string, in <-chan string) {
 				if !timer.Stop() {
 					<-timer.C
 				}
-				timer.Reset(300 * time.Millisecond)
+				timer.Reset(silenceInterval)
 			case <-timer.C:
 				for {
 					select {

--- a/reflex.go
+++ b/reflex.go
@@ -161,6 +161,10 @@ func (r *Reflex) batch(out chan<- string, in <-chan string) {
 			select {
 			case name := <-in:
 				r.backlog.Add(name)
+				if !timer.Stop() {
+					<-timer.C
+				}
+				timer.Reset(300 * time.Millisecond)
 			case <-timer.C:
 				for {
 					select {


### PR DESCRIPTION
Currently, reflex will sometimes run a command twice when I save a file, with one of those runs being on an empty file, and the other with the rest of the save.

This is because reflex batches change events for 300 milliseconds from the first change event.  But if a change series takes longer than 300 milliseconds to complete (e.g. saving or rsyncing a large file over a slow network connection) the command will be run multiple times, while seeing possibly-corrupt intermediate states of the filesystem.

This change alters the batching logic so that instead of waiting 300 milliseconds after the *first* change event, reflex will instead wait 300 milliseconds after the *last* change.  This avoids running a single-file command while a file is still changing, or running a multi-file command while a directory's contents are still in flux.  The command will instead run after the changed file(s) have stopped changing for at least 300ms.

This ensures that duplicate commands aren't run, nor do the commands operate on data that is in flux.
