### PR TITLE
Size child process ptys correctly

### DIFF
--- a/vendor/github.com/kr/pty/README.md
+++ b/vendor/github.com/kr/pty/README.md
@@ -8,6 +8,8 @@ Pty is a Go package for using unix pseudo-terminals.
 
 ## Example
 
+### Command
+
 ```go
 package main
 
@@ -32,5 +34,67 @@ func main() {
 		f.Write([]byte{4}) // EOT
 	}()
 	io.Copy(os.Stdout, f)
+}
+```
+
+### Shell
+
+```go
+package main
+
+import (
+        "io"
+        "log"
+        "os"
+        "os/exec"
+        "os/signal"
+        "syscall"
+
+        "github.com/kr/pty"
+        "golang.org/x/crypto/ssh/terminal"
+)
+
+func test() error {
+        // Create arbitrary command.
+        c := exec.Command("bash")
+
+        // Start the command with a pty.
+        ptmx, err := pty.Start(c)
+        if err != nil {
+                return err
+        }
+        // Make sure to close the pty at the end.
+        defer func() { _ = ptmx.Close() }() // Best effort.
+
+        // Handle pty size.
+        ch := make(chan os.Signal, 1)
+        signal.Notify(ch, syscall.SIGWINCH)
+        go func() {
+                for range ch {
+                        if err := pty.InheritSize(os.Stdin, ptmx); err != nil {
+                                log.Printf("error resizing pty: %s", err)
+                        }
+                }
+        }()
+        ch <- syscall.SIGWINCH // Initial resize.
+
+        // Set stdin in raw mode.
+        oldState, err := terminal.MakeRaw(int(os.Stdin.Fd()))
+        if err != nil {
+                panic(err)
+        }
+        defer func() { _ = terminal.Restore(int(os.Stdin.Fd()), oldState) }() // Best effort.
+
+        // Copy stdin to the pty and the pty to stdout.
+        go func() { _, _ = io.Copy(ptmx, os.Stdin) }()
+        _, _ = io.Copy(os.Stdout, ptmx)
+
+        return nil
+}
+
+func main() {
+        if err := test(); err != nil {
+                log.Fatal(err)
+        }
 }
 ```

--- a/vendor/github.com/kr/pty/mktypes.bash
+++ b/vendor/github.com/kr/pty/mktypes.bash
@@ -13,7 +13,7 @@ GODEFS="go tool cgo -godefs"
 $GODEFS types.go |gofmt > ztypes_$GOARCH.go
 
 case $GOOS in
-freebsd|dragonfly)
+freebsd|dragonfly|openbsd)
 	$GODEFS types_$GOOS.go |gofmt > ztypes_$GOOSARCH.go
 	;;
 esac

--- a/vendor/github.com/kr/pty/pty_darwin.go
+++ b/vendor/github.com/kr/pty/pty_darwin.go
@@ -13,19 +13,23 @@ func open() (pty, tty *os.File, err error) {
 		return nil, nil, err
 	}
 	p := os.NewFile(uintptr(pFD), "/dev/ptmx")
+	// In case of error after this point, make sure we close the ptmx fd.
+	defer func() {
+		if err != nil {
+			_ = p.Close() // Best effort.
+		}
+	}()
 
 	sname, err := ptsname(p)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	err = grantpt(p)
-	if err != nil {
+	if err := grantpt(p); err != nil {
 		return nil, nil, err
 	}
 
-	err = unlockpt(p)
-	if err != nil {
+	if err := unlockpt(p); err != nil {
 		return nil, nil, err
 	}
 

--- a/vendor/github.com/kr/pty/pty_dragonfly.go
+++ b/vendor/github.com/kr/pty/pty_dragonfly.go
@@ -14,19 +14,23 @@ func open() (pty, tty *os.File, err error) {
 	if err != nil {
 		return nil, nil, err
 	}
+	// In case of error after this point, make sure we close the ptmx fd.
+	defer func() {
+		if err != nil {
+			_ = p.Close() // Best effort.
+		}
+	}()
 
 	sname, err := ptsname(p)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	err = grantpt(p)
-	if err != nil {
+	if err := grantpt(p); err != nil {
 		return nil, nil, err
 	}
 
-	err = unlockpt(p)
-	if err != nil {
+	if err := unlockpt(p); err != nil {
 		return nil, nil, err
 	}
 

--- a/vendor/github.com/kr/pty/pty_freebsd.go
+++ b/vendor/github.com/kr/pty/pty_freebsd.go
@@ -7,22 +7,28 @@ import (
 	"unsafe"
 )
 
-func posix_openpt(oflag int) (fd int, err error) {
+func posixOpenpt(oflag int) (fd int, err error) {
 	r0, _, e1 := syscall.Syscall(syscall.SYS_POSIX_OPENPT, uintptr(oflag), 0, 0)
 	fd = int(r0)
 	if e1 != 0 {
 		err = e1
 	}
-	return
+	return fd, err
 }
 
 func open() (pty, tty *os.File, err error) {
-	fd, err := posix_openpt(syscall.O_RDWR | syscall.O_CLOEXEC)
+	fd, err := posixOpenpt(syscall.O_RDWR | syscall.O_CLOEXEC)
 	if err != nil {
 		return nil, nil, err
 	}
-
 	p := os.NewFile(uintptr(fd), "/dev/pts")
+	// In case of error after this point, make sure we close the pts fd.
+	defer func() {
+		if err != nil {
+			_ = p.Close() // Best effort.
+		}
+	}()
+
 	sname, err := ptsname(p)
 	if err != nil {
 		return nil, nil, err
@@ -42,7 +48,7 @@ func isptmaster(fd uintptr) (bool, error) {
 
 var (
 	emptyFiodgnameArg fiodgnameArg
-	ioctl_FIODGNAME   = _IOW('f', 120, unsafe.Sizeof(emptyFiodgnameArg))
+	ioctlFIODGNAME    = _IOW('f', 120, unsafe.Sizeof(emptyFiodgnameArg))
 )
 
 func ptsname(f *os.File) (string, error) {
@@ -59,8 +65,7 @@ func ptsname(f *os.File) (string, error) {
 		buf = make([]byte, n)
 		arg = fiodgnameArg{Len: n, Buf: (*byte)(unsafe.Pointer(&buf[0]))}
 	)
-	err = ioctl(f.Fd(), ioctl_FIODGNAME, uintptr(unsafe.Pointer(&arg)))
-	if err != nil {
+	if err := ioctl(f.Fd(), ioctlFIODGNAME, uintptr(unsafe.Pointer(&arg))); err != nil {
 		return "", err
 	}
 

--- a/vendor/github.com/kr/pty/pty_linux.go
+++ b/vendor/github.com/kr/pty/pty_linux.go
@@ -12,14 +12,19 @@ func open() (pty, tty *os.File, err error) {
 	if err != nil {
 		return nil, nil, err
 	}
+	// In case of error after this point, make sure we close the ptmx fd.
+	defer func() {
+		if err != nil {
+			_ = p.Close() // Best effort.
+		}
+	}()
 
 	sname, err := ptsname(p)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	err = unlockpt(p)
-	if err != nil {
+	if err := unlockpt(p); err != nil {
 		return nil, nil, err
 	}
 

--- a/vendor/github.com/kr/pty/pty_openbsd.go
+++ b/vendor/github.com/kr/pty/pty_openbsd.go
@@ -1,0 +1,33 @@
+package pty
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+func open() (pty, tty *os.File, err error) {
+	/*
+	 * from ptm(4):
+	 * The PTMGET command allocates a free pseudo terminal, changes its
+	 * ownership to the caller, revokes the access privileges for all previous
+	 * users, opens the file descriptors for the master and slave devices and
+	 * returns them to the caller in struct ptmget.
+	 */
+
+	p, err := os.OpenFile("/dev/ptm", os.O_RDWR|syscall.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer p.Close()
+
+	var ptm ptmget
+	if err := ioctl(p.Fd(), uintptr(ioctl_PTMGET), uintptr(unsafe.Pointer(&ptm))); err != nil {
+		return nil, nil, err
+	}
+
+	pty = os.NewFile(uintptr(ptm.Cfd), "/dev/ptm")
+	tty = os.NewFile(uintptr(ptm.Sfd), "/dev/ptm")
+
+	return pty, tty, nil
+}

--- a/vendor/github.com/kr/pty/pty_unsupported.go
+++ b/vendor/github.com/kr/pty/pty_unsupported.go
@@ -1,4 +1,4 @@
-// +build !linux,!darwin,!freebsd,!dragonfly
+// +build !linux,!darwin,!freebsd,!dragonfly,!openbsd
 
 package pty
 

--- a/vendor/github.com/kr/pty/util.go
+++ b/vendor/github.com/kr/pty/util.go
@@ -8,26 +8,53 @@ import (
 	"unsafe"
 )
 
+// InheritSize applies the terminal size of master to slave. This should be run
+// in a signal handler for syscall.SIGWINCH to automatically resize the slave when
+// the master receives a window size change notification.
+func InheritSize(master, slave *os.File) error {
+	size, err := GetsizeFull(master)
+	if err != nil {
+		return err
+	}
+	err = Setsize(slave, size)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Setsize resizes t to s.
+func Setsize(t *os.File, ws *Winsize) error {
+	return windowRectCall(ws, t.Fd(), syscall.TIOCSWINSZ)
+}
+
+// GetsizeFull returns the full terminal size description.
+func GetsizeFull(t *os.File) (size *Winsize, err error) {
+	var ws Winsize
+	err = windowRectCall(&ws, t.Fd(), syscall.TIOCGWINSZ)
+	return &ws, err
+}
+
 // Getsize returns the number of rows (lines) and cols (positions
 // in each line) in terminal t.
 func Getsize(t *os.File) (rows, cols int, err error) {
-	var ws winsize
-	err = windowrect(&ws, t.Fd())
-	return int(ws.ws_row), int(ws.ws_col), err
+	ws, err := GetsizeFull(t)
+	return int(ws.Rows), int(ws.Cols), err
 }
 
-type winsize struct {
-	ws_row    uint16
-	ws_col    uint16
-	ws_xpixel uint16
-	ws_ypixel uint16
+// Winsize describes the terminal size.
+type Winsize struct {
+	Rows uint16 // ws_row: Number of rows (in cells)
+	Cols uint16 // ws_col: Number of columns (in cells)
+	X    uint16 // ws_xpixel: Width in pixels
+	Y    uint16 // ws_ypixel: Height in pixels
 }
 
-func windowrect(ws *winsize, fd uintptr) error {
+func windowRectCall(ws *Winsize, fd, a2 uintptr) error {
 	_, _, errno := syscall.Syscall(
 		syscall.SYS_IOCTL,
 		fd,
-		syscall.TIOCGWINSZ,
+		a2,
 		uintptr(unsafe.Pointer(ws)),
 	)
 	if errno != 0 {

--- a/vendor/github.com/kr/pty/ztypes_openbsd_amd64.go
+++ b/vendor/github.com/kr/pty/ztypes_openbsd_amd64.go
@@ -1,0 +1,13 @@
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs types_openbsd.go
+
+package pty
+
+type ptmget struct {
+	Cfd int32
+	Sfd int32
+	Cn  [16]int8
+	Sn  [16]int8
+}
+
+var ioctl_PTMGET = 0x40287401

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -21,10 +21,10 @@
 			"revisionTime": "2016-08-23T17:07:15Z"
 		},
 		{
-			"checksumSHA1": "jHOLsfeMPcX84YQB2MXBqXFntBg=",
+			"checksumSHA1": "ym3Koe72EEWlnhyjCmuC0FSlDyw=",
 			"path": "github.com/kr/pty",
-			"revision": "95d05c1eef33a45bd58676b6ce28d105839b8d0b",
-			"revisionTime": "2017-10-06T17:48:01Z"
+			"revision": "282ce0e5322c82529687d609ee670fac7c7d917c",
+			"revisionTime": "2018-01-13T18:08:13Z"
 		},
 		{
 			"checksumSHA1": "yHHAiCGQPKOlbQZKsxZrY/PL+cw=",


### PR DESCRIPTION
Currently, child processes see a terminal size of 80x24, regardless of the actual display size.  This PR updates the `kr/pty` dependency to a version that supports terminal resizing, and adds the code to statically and dynamically size the child pty to match the parent.