### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ background on this issue.
 * https://github.com/mynyml/watchr
 * https://github.com/eaburns/Watch
 * https://github.com/alloy/kicker
+* https://github.com/clibs/entr
 
 ### Why you should use reflex instead
 


### PR DESCRIPTION
Add entr to competition, didn't add anything more cause Why you should use reflex instead sums it up nicely.