### PR TITLE
Addition of path substitution

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ The following is given by running `reflex -h`:
 Usage: reflex [OPTIONS] [COMMAND]
 
 COMMAND is any command you'd like to run. Any instance of {} will be replaced
-with the filename of the changed file. (The symbol may be changed with the
---substitute flag.)
+with the filename of the changed file and || will be replaced with the path to the changed file. (The symbol may be changed with the
+--substitute or --pathsubstitute flag.)
 
 OPTIONS are given below:
       --all=false:
@@ -50,6 +50,9 @@ OPTIONS are given below:
             Only match directories (not files).
       --only-files=false:
             Only match files (not directories).
+      --pathsubstitute="||": 
+            The substitution symbol that is replace with the path to the file
+            in a command.
   -r, --regex=[]:
             A regular expression to match filenames. (May be repeated.)
   -e, --sequential=false:
@@ -117,8 +120,8 @@ changed.
 ### Substitution
 
 Reflex provides a way for you to determine, inside your command, what file
-changed. This is via a substitution symbol. The default is `{}`. Every instance
-of the substitution symbol inside your command is replaced by the filename.
+changed and the path to the file. This is via a substitution symbol. The default is `{}` for files and `||` for paths. Every instance
+of the substitution symbol inside your command is replaced by the filename or path.
 
 As a simple example, suppose you're writing Coffeescript and you wish to compile
 the CS files to Javascript when they change. You can do this with:

--- a/README.md
+++ b/README.md
@@ -335,3 +335,4 @@ background on this issue.
 * Rich Liebling ([rliebling](https://github.com/rliebling))
 * Seth W. Klein ([sethwklein](https://github.com/sethwklein))
 * Vincent Vanackere ([vanackere](https://github.com/vanackere))
+* Richard Cox ([Khabi](https://github.com/Khabi))

--- a/config.go
+++ b/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	inverseRegexes  []string
 	inverseGlobs    []string
 	subSymbol       string
+	subPathSymbol   string
 	startService    bool
 	shutdownTimeout time.Duration
 	onlyFiles       bool
@@ -42,6 +43,9 @@ func (c *Config) registerFlags(f *flag.FlagSet) {
 	f.StringVar(&c.subSymbol, "substitute", defaultSubSymbol, `
             The substitution symbol that is replaced with the filename
             in a command.`)
+    f.StringVar(&c.subPathSymbol, "pathsubstitute", defaultSubPathSymbol, `
+    		The substitution symbol that is replace with the path to the file
+    		in a command.`)
 	f.BoolVarP(&c.startService, "start-service", "s", false, `
             Indicates that the command is a long-running process to be
             restarted on matching changes.`)

--- a/config.go
+++ b/config.go
@@ -43,7 +43,7 @@ func (c *Config) registerFlags(f *flag.FlagSet) {
 	f.StringVar(&c.subSymbol, "substitute", defaultSubSymbol, `
             The substitution symbol that is replaced with the filename
             in a command.`)
-    f.StringVar(&c.subPathSymbol, "pathsubstitute", defaultSubPathSymbol, `
+	f.StringVar(&c.subPathSymbol, "pathsubstitute", defaultSubPathSymbol, `
     		The substitution symbol that is replace with the path to the file
     		in a command.`)
 	f.BoolVarP(&c.startService, "start-service", "s", false, `

--- a/config_test.go
+++ b/config_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestReadConfigs(t *testing.T) {
-	const in = `-g '*.go' echo {}
+	const in = `-g '*.go' echo {} ||
 
 # Some comment here
 -r '^a[0-9]+\.txt$' --only-dirs --substitute='[]' echo []
@@ -28,10 +28,11 @@ world"
 	}
 	want := []*Config{
 		{
-			command:         []string{"echo", "{}"},
+			command:         []string{"echo", "{}", "||"},
 			source:          "test input, line 1",
 			globs:           []string{"*.go"},
 			subSymbol:       "{}",
+			subPathSymbol:   "||",
 			shutdownTimeout: 500 * time.Millisecond,
 		},
 		{
@@ -39,6 +40,7 @@ world"
 			source:          "test input, line 4",
 			regexes:         []string{`^a[0-9]+\.txt$`},
 			subSymbol:       "[]",
+			subPathSymbol:   "||",
 			shutdownTimeout: 500 * time.Millisecond,
 			onlyDirs:        true,
 		},
@@ -47,6 +49,7 @@ world"
 			source:          "test input, line 6",
 			globs:           []string{"*.go"},
 			subSymbol:       "{}",
+			subPathSymbol:   "||",
 			startService:    true,
 			shutdownTimeout: 500 * time.Millisecond,
 			onlyFiles:       true,
@@ -59,6 +62,7 @@ world"
 			inverseRegexes:  []string{"baz"},
 			inverseGlobs:    []string{"b", "c"},
 			subSymbol:       "{}",
+			subPathSymbol:   "||",
 			shutdownTimeout: 500 * time.Millisecond,
 		},
 	}
@@ -76,6 +80,7 @@ func TestReadConfigsBad(t *testing.T) {
 		"--substitute='' echo hi",
 		"-s echo {}",
 		"--only-files --only-dirs echo hi",
+		"--pathsubstitute='' echo hi",
 	} {
 		r := strings.NewReader(in)
 		if configs, err := readConfigsFromReader(r, "test input"); err == nil {

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 )
 
 const defaultSubSymbol = "{}"
+const defaultSubPathSymbol = "||"
 
 var (
 	reflexes []*Reflex

--- a/reflex.go
+++ b/reflex.go
@@ -19,17 +19,17 @@ import (
 
 // A Reflex is a single watch + command to execute.
 type Reflex struct {
-	id           int
-	source       string // Describes what config/line defines this Reflex
-	startService bool
-	backlog      Backlog
-	matcher      Matcher
-	onlyFiles    bool
-	onlyDirs     bool
-	command      []string
-	subSymbol    string
-	subPathSymbol   string
-	done         chan struct{}
+	id            int
+	source        string // Describes what config/line defines this Reflex
+	startService  bool
+	backlog       Backlog
+	matcher       Matcher
+	onlyFiles     bool
+	onlyDirs      bool
+	command       []string
+	subSymbol     string
+	subPathSymbol string
+	done          chan struct{}
 
 	mu      *sync.Mutex // protects killed and running
 	killed  bool
@@ -64,7 +64,7 @@ func NewReflex(c *Config) (*Reflex, error) {
 
 	substitution := false
 	for _, part := range c.command {
-		if strings.Contains(part, c.subSymbol) || strings.Contains(part, c.subPathSymbol){
+		if strings.Contains(part, c.subSymbol) || strings.Contains(part, c.subPathSymbol) {
 			substitution = true
 			break
 		}
@@ -89,19 +89,19 @@ func NewReflex(c *Config) (*Reflex, error) {
 	}
 
 	reflex := &Reflex{
-		id:           reflexID,
-		source:       c.source,
-		startService: c.startService,
-		backlog:      backlog,
-		matcher:      matcher,
-		onlyFiles:    c.onlyFiles,
-		onlyDirs:     c.onlyDirs,
-		command:      c.command,
-		subSymbol:    c.subSymbol,
+		id:            reflexID,
+		source:        c.source,
+		startService:  c.startService,
+		backlog:       backlog,
+		matcher:       matcher,
+		onlyFiles:     c.onlyFiles,
+		onlyDirs:      c.onlyDirs,
+		command:       c.command,
+		subSymbol:     c.subSymbol,
 		subPathSymbol: c.subPathSymbol,
-		done:         make(chan struct{}),
-		timeout:      c.shutdownTimeout,
-		mu:           &sync.Mutex{},
+		done:          make(chan struct{}),
+		timeout:       c.shutdownTimeout,
+		mu:            &sync.Mutex{},
 	}
 	reflexID++
 


### PR DESCRIPTION
In some cases when using reflex it makes sense to allow the path to the file changed to be used in the command.

A real life example is something like this:
`-g 'pkg/auth/auth.proto' -- /go/bin/protoc -I pkg/ -I pkg/auth/ -I /go/src/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis/ -I /go/include/ --grpc-gateway_out=logtostderr=true:pkg/auth/ {}`

In order for that command to run I need that path to the file `pkg/auth/auth.proto` and the path `pkg/auth/`.  Since not all the .proto files live in the same path, I'd have to duplicate that command for every glob that isn't in /pkg/auth/

This allows you to use `||` by default as a placeholder for the path to the changed file.  This lets you replace the above with the following and eliminate any duplication.

`-g '*/*/*.proto' -- /go/bin/protoc -I pkg/ -I ||-I /go/src/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis/ -I /go/include/ --grpc-gateway_out=logtostderr=true:|| {}`