### PR TITLE
Use default config file if exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ with the filename of the changed file. (The symbol may be changed with the
 OPTIONS are given below:
       --all=false:
             Include normally ignored files (VCS and editor special files).
-  -c, --config="":
+  -c, --config="reflex.conf":
             A configuration file that describes how to run reflex
             (or '-' to read the configuration from stdin).
   -d, --decoration="plain":
@@ -135,6 +135,10 @@ applications I often want to rebuild/rerun the server when my code changes, but
 also build SCSS and Coffeescript when those change as well. Instead of running
 multiple reflex instances, which is cumbersome (and inefficient), you can give
 reflex a configuration file.
+
+If a configuration file is not specified, and a file named `reflex.conf` exists
+in the current directory, reflex automatically picks that file as the default
+configuration file.
 
 The configuration file syntax is simple: each line is a command, and each
 command is composed of flags and arguments -- just like calling reflex but


### PR DESCRIPTION
Fixes #41

I was going through my issues list and saw that I had opened a feature request (2.5 years ago, sorry) for a "rc file" in the current directory, such that if it exists, it is automatically used if `--config` flag is not set. I believe we settled on a straightforward name for the config file: `reflex.conf`. This PR implements that in a very simple, straightforward way:

Before the config flag is processed, we check if it's empty and if `reflex.conf` exists. If it does, the flag is quietly set to that value before rest of the flag processing takes place. I also modified the wording of an error to indicate that the flag validation behavior is the same whether `--config` flag is specified or assumed (to be `=reflex.conf`).

I tested this by building the reflex binary and running it in a directory with and without a `reflex.conf` file and it seems to meet the expectations in this rudimentary, manual test. I'm not sure how to add an automated test for this. Contents of `main()` do not seem to be autotested anyway.

I should also update the documentation before this is ready for review.

Edit: Also, prefer not to add my name to authors list. This is extremely trivial and I don't feel that I deserve the credit.