### PR TITLE
Add goreleaser support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /reflex
 /Reflexfile
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,19 @@
+builds:
+  -
+    binary: reflex
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+
+archives:
+  -
+    replacements:
+      amd64: 64-bit
+      386: 32-bit
+      darwin: MacOS
+      linux: Linux
+    files:
+      - README.md
+      - LICENSE

--- a/README.md
+++ b/README.md
@@ -11,13 +11,17 @@ for reloading your application when the code changes.
 
 ## Installation
 
+Reflex probably only works on Linux and Mac OS.
+
+### From Binary Release
+
+Download the release for your OS from the [releases](https://github.com/cespare/reflex/releases).
+
+### From Source (via Go)
+
 You'll need Go 1.11+ installed:
 
     $ go get github.com/cespare/reflex
-
-Reflex probably only works on Linux and Mac OS.
-
-TODO: provide compiled downloads for linux/darwin amd64.
 
 ## Usage
 


### PR DESCRIPTION
This PR adds support for the minimum needed goreleaser config to generate releases with binaries. This resolves #31 and is an alternative to #67.

An example on my fork of a release is: https://github.com/kpurdon/reflex/releases/tag/v0.2.1

This can currently be run by doing the following:
1. Do some work, commit it, push it, create and push a tag.
2. Make sure `GITHUB_TOKEN="a_repo_scope_github_token"` is set.
3. Run `goreleaser`.

This is more or less from the example here: https://goreleaser.com/quick-start/.

I avoided adding any automation (TravisCI, Github Actions, ...) since that would be difficult for me to test, but those things are supported:

- https://goreleaser.com/ci/
- https://goreleaser.com/actions/

The process for this would be to merge, tag a new release, and run goreleaser (following my steps above) to create a new release with binaries.