### PR TITLE
Publish artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      -
+        name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,35 @@
+before:
+  hooks:
+    - go mod download
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+archives:
+  - id: binaries
+    format: binary
+    replacements:
+      darwin: Darwin
+      linux: Linux
+      386: i386
+      amd64: x86_64
+
+  - id: archives
+    format: tar.gz
+    replacements:
+      darwin: Darwin
+      linux: Linux
+      386: i386
+      amd64: x86_64
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'

--- a/README.md
+++ b/README.md
@@ -11,13 +11,17 @@ for reloading your application when the code changes.
 
 ## Installation
 
+Reflex only works on Linux and Mac OS.
+
+### Prebuilt Binaries
+
+You can download the appropriate binary from the [releases page](https://github.com/cespare/reflex/releases).
+
+### Build from source
+
 You'll need Go 1.11+ installed:
 
     $ go get github.com/cespare/reflex
-
-Reflex probably only works on Linux and Mac OS.
-
-TODO: provide compiled downloads for linux/darwin amd64.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -336,3 +336,4 @@ background on this issue.
 * Rich Liebling ([rliebling](https://github.com/rliebling))
 * Seth W. Klein ([sethwklein](https://github.com/sethwklein))
 * Vincent Vanackere ([vanackere](https://github.com/vanackere))
+* Joe Wilner ([jwilner](https://github.com/jwilner))


### PR DESCRIPTION
# Publish Artifacts

This PR is a one-stop shop for publishing binaries and archives. Adoption is simple:

1. merge this PR
2. push a tag:

```shell
git tag -a -m "Publish build artifacts" v0.4.0
git push --tags
```

## TL;DR

This PR adds popular tool [GoReleaser](https://github.com/goreleaser/goreleaser) and GitHub actions to automatically publish unwrapped binaries, .tar.gz archives, and checksums for MacOS and Linux to GitHub releases whenever a tag is pushed. Example output is visible in the fork's [releases page](https://github.com/jwilner/reflex/releases/tag/v0.4.0).

## Targets

I added targets for both plain binaries and archives. The plain binaries themselves clock in at ~2MB, so there's not much value to the compression of the archives, but the archives also send along the license and README. Checksums for everything are included.

## Tech Choices

This PR adopts some very common and popular technology for this project.

### GoReleaser

`goreleaser` is a very popular and extensible tool for automating release cycles. It is itself a CLI binary, but here we use its GitHub action (Docker container) to make the process as automated as possible. Currently, we define two targets -- vanilla binaries and `tar.gz`s of a directory containing the license, README, and binary. 

#### Flexibility

- Here we target GOOSs linux and darwin, but if Windows support were later added to `reflex`, `goreleaser` would support that as well.
- `goreleaser` supports automating releases to package managers like `brew` and `snap` (with additional customization of course)

### GitHub Actions

[GitHub Actions](https://github.com/features/actions) is the most accessible CI/CD platform for a GitHub repository, as with this project.

### GitHub Releases

Again, GitHub releases are the most accessible place to store your build artifacts when you've got a GitHub repository. Speaking as a GitHub user, I suspect it's the first place most people look for downloads.

## Related issues:

- https://github.com/cespare/reflex/issues/31
- https://github.com/cespare/reflex/pull/69
- https://github.com/cespare/reflex/pull/67