### PR TITLE
docs(readme): add goblin.run as an option for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ version directly with
 
     go install github.com/cespare/reflex@latest
 
+
+If you don't have Go installed and would like a binary custom built for your system , you can use [goblin.run](https://goblin.run)
+
+    curl -sf https://goblin.run/github.com/cespare/reflex | sh
+
 Reflex is only tested on Linux and macOS.
 
 ## Usage


### PR DESCRIPTION
Adds goblin.run to allow compilation for all arch and os options. 

I know reflex is only tested on mac and linux but the option to try it out on others does help 


We already have 
https://github.com/air-verse/air and a few of my packages using this for a while now 


