### PR TITLE
Ignore .jj directory by default

### DIFF
--- a/defaultexclude.go
+++ b/defaultexclude.go
@@ -4,6 +4,7 @@ import "regexp"
 
 var defaultExcludes = []string{
 	// VCS dirs
+	`(^|/)\.jj/`,
 	`(^|/)\.git/`,
 	`(^|/)\.hg/`,
 	// Vim


### PR DESCRIPTION
[Jujutsu](https://docs.jj-vcs.dev/) is a VCS that's growing in popularity. It uses a `.jj` directory, very similar to `.git` or `.hg`, and should be added to the default ignore list to avoid `too many files open` errors.